### PR TITLE
Fix sun3.php sun position circle display for all browsers

### DIFF
--- a/sun3.php
+++ b/sun3.php
@@ -1,5 +1,5 @@
 <?php
-$scrpt_vrsn_dt  = 'sun3.php|00|2019-01-13|';  # first version
+$scrpt_vrsn_dt  = 'sun3.php|00|2019-01-24|';  # first version
 # 
 # weather34 template for use with Cumulus->realtime.txt
 # original version by BRIAN UNDERDOWN 2015-2016-2017-2018


### PR DESCRIPTION
This uses a new method to draw a circle representing the sun position on the 24hr circle.
It replaces the zero length arc method which only worked on Chrome and Firefox Developer.
This method works on Firefox, Chrome, Opera, Edge, IE, and Safari (iOS tested)