### PR TITLE
Updates for automatic DarkSky language selection

### DIFF
--- a/common.php
+++ b/common.php
@@ -1,8 +1,9 @@
 <?php
-include('settings1.php');
+include_once('settings1.php');
 date_default_timezone_set($TZ);
 //translations for HOMEWEATHERSTATION TEMPLATE UPDATED 2nd November added set locale
 /* mb_ functions not used - ktrue - 11-Jan-2019
+  $language set to DarkSky language (doesn't always match $lang in the scripts)
 mb_internal_encoding('UTF-8');
 mb_http_output('UTF-8');
 mb_http_input('UTF-8');
@@ -49,7 +50,7 @@ switch ($lang) {
   $lang_flag = 'can';
   $lang_option = 'can';
 	$language = 'en';
-  setlocale(LC_TIME, "en_EN");
+  setlocale(LC_TIME, "en_CA");
   break;
   
   //english	us
@@ -67,7 +68,7 @@ switch ($lang) {
   $lang_flag = 'dk';
   $lang_option = 'en'; 
 	$language = 'da';
-  setlocale(LC_TIME, 'danish', 'DK', 'da_DK.ISO8859-1', 'da_DK.utf-8');
+  setlocale(LC_TIME, 'danish.utf8',  'da_DK.utf8');
   break;
   
   
@@ -77,7 +78,7 @@ switch ($lang) {
   $lang_flag = 'nl';
   $lang_option = 'en';
 	$language = 'nl';
-  setlocale(LC_TIME, "nl_NL.UTF-8");
+  setlocale(LC_TIME, 'dutch.utf8',"nl_NL.utf8");
   break;
   
   
@@ -87,7 +88,7 @@ switch ($lang) {
   $lang_flag = 'br';
   $lang_option = 'en';
 	$language = 'pt';
-  setlocale(LC_TIME, "pt_BR.UTF-8");
+  setlocale(LC_TIME, 'portugues.utf8',"pt_BR.utf8");
   break;
   
   //argentine
@@ -96,7 +97,7 @@ switch ($lang) {
   $lang_flag = 'ar';
   $lang_option = 'en';
 	$language = 'es';
-  setlocale(LC_TIME, "es_ES.UTF-8");
+  setlocale(LC_TIME, 'spanish.utf8',"es_ES.utf8");
   break;
   
     
@@ -106,7 +107,7 @@ switch ($lang) {
   $lang_flag = 'pl';
   $lang_option = 'en';
 	$language = 'pl';
-  setlocale(LC_TIME, 'pl_PL', 'pl_PL.ISO8859-2', 'polish_pol');
+  setlocale(LC_TIME, 'polish.utf8', 'pl_PL.utf8', 'polish_pol.utf8');
   break;
   
   
@@ -116,7 +117,7 @@ switch ($lang) {
   $lang_flag = 'dl';
   $lang_option = 'en';
 	$language = 'de';
-  setlocale(LC_TIME, "de_DE.UTF-8");
+  setlocale(LC_TIME, 'german.utf8', "de_DE.utf8");
   break;
   
   //italian
@@ -125,7 +126,7 @@ switch ($lang) {
   $lang_flag = 'it';
   $lang_option = 'en';
 	$language = 'it';
-  setlocale(LC_TIME, "it_IT.UTF-8");
+  setlocale(LC_TIME, 'italian.utf8', "it_IT.utf8");
   break;
   
 //spanish
@@ -134,6 +135,7 @@ switch ($lang) {
   $lang_flag = 'sp';
   $lang_option = 'en';
 	$language = 'es';
+  setlocale(LC_TIME, 'spanish.utf8', "es_ES.utf8");
   break;
   
   
@@ -143,7 +145,7 @@ switch ($lang) {
   $lang_flag = 'cat';
   $lang_option = 'en';
 	$language = 'ca';
-  setlocale(LC_TIME, "ca_ES");
+  setlocale(LC_TIME, 'catalan.utf8', "ca_ES.utf8");
   break; 
   
 //french  
@@ -152,7 +154,7 @@ switch ($lang) {
   $lang_flag = 'fr';
   $lang_option = 'en';
 	$language = 'fr';
-  setlocale(LC_TIME, "fr_FR.UTF-8");
+  setlocale(LC_TIME, 'french.utf8', "fr_FR.utf8");
   break;
   
 //greek  
@@ -161,7 +163,7 @@ switch ($lang) {
   $lang_flag = 'gr';
   $lang_option = 'en';
 	$language = 'el';
-  setlocale(LC_TIME, "el_GR.UTF-8");
+  setlocale(LC_TIME, "el_GR.utf8",'el_GR','greek.utf8');
   break;
 
 //turkish  
@@ -170,7 +172,7 @@ switch ($lang) {
   $lang_flag = 'tr';
   $lang_option = 'en';
 	$language = 'tr';
-  setlocale(LC_TIME, "tr_TR.UTF-8");
+  setlocale(LC_TIME, 'turkish.utf8',"tr_TR.utf8");
   break;
   
 //swedish 
@@ -179,7 +181,7 @@ switch ($lang) {
   $lang_flag = 'sv';
   $lang_option = 'sv';
 	$language = 'sv';
-  setlocale(LC_TIME, "sv_SE.UTF-8");
+  setlocale(LC_TIME, 'swedish.utf8',"sv_SE.utf8");
   break;
   
 //default
@@ -188,7 +190,7 @@ switch ($lang) {
   $lang_flag = $defaultlanguage;
   $lang_option = 'en';
 	$language = 'en';
-  setlocale(LC_TIME, "");
+  setlocale(LC_TIME, "en_US.utf8", "en_US");
   }
 
 

--- a/forecast3ds.php
+++ b/forecast3ds.php
@@ -1,6 +1,10 @@
 <?php
+// 31-Jan-2019 DarkSky multilanguage support added - ktrue
+include_once('settings.php');
+include_once('common.php');
 include_once('livedata.php');
-error_reporting(0); date_default_timezone_set($TZ);include('common.php');
+error_reporting(0); date_default_timezone_set($TZ);
+header('Content-type: text/html; charset=UTF-8');
 
 	####################################################################################################
 	#	HOME WEATHER STATION TEMPLATE by BRIAN UNDERDOWN 2016-17                                       #
@@ -20,9 +24,9 @@ error_reporting(0); date_default_timezone_set($TZ);include('common.php');
 <?php 
 
 
-$forecastime=filemtime('jsondata/darksky.txt');
+$forecastime=filemtime('jsondata/darksky-'.$language.'.txt');
 	$weather34wuurl = file_get_contents("jsondata/dark.txt");
-	if(filesize('jsondata/darksky.txt')<1){echo "".$offline. " Offline<br>";}else echo $online,"";echo " ",	date($timeFormat,$forecastime);	?></div>
+	if(filesize('jsondata/darksky-'.$language.'.txt')<1){echo "".$offline. " Offline<br>";}else echo $online,"";echo " ",	date($timeFormat,$forecastime);	?></div>
 		<?php
 		
 	$rainsvg= '<svg id="weather34 raindrop" x="0px" y="0px" viewBox="0 0 512 512" width="8px" fill="#01a4b5" stroke="#01a4b5" stroke-width="3%"><g><g><path d="M348.242,124.971C306.633,58.176,264.434,4.423,264.013,3.889C262.08,1.433,259.125,0,256,0	c-3.126,0-6.079,1.433-8.013,3.889c-0.422,0.535-42.621,54.287-84.229,121.083c-56.485,90.679-85.127,161.219-85.127,209.66

--- a/forecastdshour.php
+++ b/forecastdshour.php
@@ -1,5 +1,9 @@
 <?php
-include_once('settings.php');include('livedata.php');header('Content-type: text/html; charset=utf-8');
+// 31-Jan-2019 DarkSky multilanguage support added - ktrue
+include_once('settings.php');
+include_once('common.php');
+include_once('livedata.php');
+header('Content-type: text/html; charset=utf-8');
 
 	####################################################################################################
 	#	HOME WEATHER STATION TEMPLATE by BRIAN UNDERDOWN 2016                                          #
@@ -89,7 +93,13 @@ border:0;color:#aaa;overflow:hidden!important;margin-bottom:5px;border:solid 1px
             $darkskyhourlyHumidity = $cond['humidity']*100;
             $darkskyhourlyPrecipProb = $cond['precipProbability']*100;
             if (isset($cond['precipType'])){
-            $darkskyhourlyPrecipType = $cond['precipType'];}
+              $darkskyhourlyPrecipType = $cond['precipType'];
+							if(isset($lang[ucfirst($darkskyhourlyPrecipType)])) {
+								$darkskyhourlyPrecipType = $lang[ucfirst($darkskyhourlyPrecipType)];
+							}
+						} else {
+							$darkskyhourlyPrecipType = '&nbsp;';
+						}
 			$darkskyhourlyprecipIntensity = number_format($cond['precipIntensityMax'],1);         
             $darkskyhourlyWindSpeed = round($cond['windSpeed'],0);
 			$darkskyhourlyWindGust = round($cond['windGust'],0);

--- a/jsondata/wuupdate.php
+++ b/jsondata/wuupdate.php
@@ -1,7 +1,9 @@
 <?php
+// 31-Jan-2019 DarkSky multilanguage support added - ktrue
 chdir(dirname(__FILE__));
 include_once('../settings.php');
 include_once('../settings1.php');
+include_once('../common.php');
 date_default_timezone_set($TZ);
 // NEW checkwx.com API 
 if(file_exists('metar34.txt')&&time()- filemtime('metar34.txt')>1800){
@@ -19,11 +21,12 @@ $result = curl_exec ($ch5);
 curl_close ($ch5);}
 ?>
 <?php
-if(file_exists('darksky.txt')&&time()- filemtime('darksky.txt')>3600){
+$filename4 = 'darksky-'.$language.'.txt';
+if(!file_exists($filename4) or 
+  (file_exists($filename4)&&time()- filemtime($filename4)>3600)){
 // weather34 darksky  curl based
 $url4 = 'https://api.forecast.io/forecast/'.$apikey.'/'.$lat.','.$lon.'?lang='.$language.'&units='.$darkskyunit ;
 $ch4 = curl_init($url4);
-$filename4 = 'darksky.txt';
 $complete_save_loc4 = $filename4; 
 $fp4 = fopen($complete_save_loc4, 'wb'); 
 curl_setopt($ch4, CURLOPT_FILE, $fp4);

--- a/livedata.php
+++ b/livedata.php
@@ -1,5 +1,6 @@
 <?php 
-	####################################################################################################
+// 31-Jan-2019 DarkSky multilanguage support added - ktrue
+####################################################################################################
 	#	HOME WEATHER STATION TEMPLATE by BRIAN UNDERDOWN 2015-2016-2017                                #
 	#	CREATED FOR HOMEWEATHERSTATION TEMPLATE at https://weather34.com/homeweatherstation            # 
 	# 	                                                                                               #
@@ -8,7 +9,8 @@
 	# 	                                                                                               #
 	#   https://www.weather34.com 	                                                                   #
 	####################################################################################################
- include('settings.php');include('shared.php');
+ include_once('settings.php');
+ include_once('shared.php');
  error_reporting(0); 
  
 $file1 = 'jsondata/weatherflow.txt';
@@ -406,7 +408,7 @@ if ($weather["wind_units"] == 'mph') {
 // darksky api forecast and current script for HOMEWEATHERSTATION gets data from jsondata/darksky.json Friday 2nd December 2016 //
 //$units = 'auto';  // Read the API docs for full details // default is auto
 date_default_timezone_set($TZ);
-$json = 'jsondata/darksky.txt'; 
+$json = 'jsondata/darksky-'.$language.'.txt'; 
 $json = file_get_contents($json); 
 $response = json_decode($json, true);       
 if ($response != null) {

--- a/outlookds.php
+++ b/outlookds.php
@@ -1,6 +1,11 @@
 <?php
-include_once('settings.php');include('livedata.php');include('common.php');
-
+// 31-Jan-2019 - added DarkSky multilanguage support - ktrue
+error_reporting(E_ALL);
+include_once('settings.php');
+include_once('common.php');
+include_once('livedata.php');
+ini_set('default_charset','UTF-8');
+header('Content-type: text/html; charset=UTF-8');
 	####################################################################################################
 	#	HOME WEATHER STATION TEMPLATE by BRIAN UNDERDOWN 2016-18                                       #
 	#	CREATED FOR HOMEWEATHERSTATION TEMPLATE at https://weather34.com/homeweatherstation/index.html # 
@@ -108,7 +113,7 @@ border:0;color:#aaa;overflow:hidden!important;margin-bottom:5px;border:solid 1px
 		 <div class="darkskyforecasthome">
 		<div class="darkskydiv">
 		  <?php
-        
+        print "<!-- language='$language' darkskyCond = ".count($darkskyCond)." entries. -->\n";
         foreach ($darkskydayCond as $cond) {
             $darkskydayTime = $cond['time'];
             $darkskydaySummary = $cond['summary'];
@@ -121,7 +126,10 @@ border:0;color:#aaa;overflow:hidden!important;margin-bottom:5px;border:solid 1px
 			$darkskydayUV = $cond['uvIndex'];
 			
             if (isset($cond['precipType'])){
-            $darkskydayPrecipType = $cond['precipType'];}
+              $darkskydayPrecipType = $cond['precipType'];
+						} else {
+							$darkskydayPrecipType = '';
+						}
 			$darkskydayacumm=round($cond['precipAccumulation'],1);
 			$darkskydayprecipIntensity = number_format($cond['precipIntensityMax'],1);         
             $darkskydayWindSpeed = round($cond['windSpeed'],0);
@@ -160,7 +168,7 @@ border:0;color:#aaa;overflow:hidden!important;margin-bottom:5px;border:solid 1px
 				  echo ''.$snowflakesvg.'&nbsp;<darkskytempwindhome><span>Snow <blue1>&nbsp;'.$darkskydayacumm.'</blue1> cm</darkskywindhome><br></span>';}  
 				  
 				  else if ($darkskydayPrecipType='rain'){
-				  echo ''.$rainsvg.'&nbsp;<darkskytempwindhome><span>Rain <blue1>&nbsp;'. $darkskydayprecipIntensity.'</blue1>'.$rainunit.'&nbsp;<blue1>'.$darkskydayPrecipProb.'</blue1>%</darkskywindhome></span>';}  
+				  echo ''.$rainsvg.'&nbsp;<darkskytempwindhome><span>'.$lang['Rain'].' <blue1>&nbsp;'. $darkskydayprecipIntensity.'</blue1>'.$rainunit.'&nbsp;<blue1>'.$darkskydayPrecipProb.'</blue1>%</darkskywindhome></span>';}  
 				   
 				  echo  '</div>';}?></div></div></div>                
                   


### PR DESCRIPTION
These updates provide for darksky-LL.txt individual cache files
so on change of language by menu, the correct language will be used
for DarkSky 3 day, 10 day and hourly forecast displays.
common.php updated for new LC_TIME locale descriptors to use UTF-8 encoding
for day/month names in DarkSky forecasts.