### PR TITLE
Add easy menu extras capability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,8 @@ demodata/*
 # ignore settings1.php as it contains the user's current configuration
 settings1.php
 
+# ignore menu-extras.php as it contains the user's current configuration
+menu-extras.php
+
 # ignore all compare backup files
 *.bak

--- a/menu-extras-template.php
+++ b/menu-extras-template.php
@@ -1,0 +1,18 @@
+<?php
+/*
+menu-extras.php is a file in which you can put extra menu items you'd like to appear in the CU-HWS menu
+
+Entries have the format:
+
+Entries have the format:
+
+Show link in a new blank page:
+
+<li><a href="diags.php?show=info" target="_blank"><?php echo $info?> Diagnostics page</a></li>
+
+Show link in a iframe browser (for secondary HWS modules)
+
+<li><a href="mooninfo.php" data-featherlight="iframe"><?php echo $info?> Moon Info</a></li>
+
+*/ 
+?>

--- a/menu.php
+++ b/menu.php
@@ -1,4 +1,4 @@
-<!-- begin menu.php 30-Mar-2019 -->
+<!-- begin menu.php 13-Apr-2019 -->
 <header style="z-index:auto">
 <h1><ogreyh1><?php echo $stationName;?>&nbsp; Home &#8226; Weather &#8226; Station </ogreyh1></h1>
 <button class="button right"></button><div class='w34logo'>
@@ -34,8 +34,14 @@ else echo' <a class="menucolor" href="./?units=metric">Units</a>';?></div>
 <?php if($weatherflowoption=="yes"){ echo "<li><a href=https://staging.smartweather.weatherflow.com/map/".$lat."/".$lon."/".$weatherflowmapzoom." data-featherlight=iframe>". $locationinfo." Weatherflow Map </a></li>" ;}
 ?>
 <li><!-- webcam --> <a href="webcam.php" data-featherlight="iframe" title="WEATHERSTATION WEBCAM"> <?php echo $webcam34icon;?> Web Cam </a></li>  
-<li><!-- info --> <a href="bio.php" data-featherlight="iframe" title="Contact WEATHERSTATION Info"> <?php echo $svgmailmenu;?> Contact Info</a></li>  
-
+<li><!-- info --> <a href="bio.php" data-featherlight="iframe" title="Contact WEATHERSTATION Info"> <?php echo $svgmailmenu;?> Contact Info</a></li> 
+<?php 
+if (file_exists('menu-extras.php')) {
+	include_once('menu-extras.php');
+} else if(file_exists('menu-extras-template.php')) {
+	copy('menu-extras-template.php','menu-extras.php');
+}
+?>
 <!-- languages --> 
 <?php if($languages=="yes") echo '<li><a href="">
    


### PR DESCRIPTION
Add extra links to the menu by editing menu-extras.php
The menu-extras.php will be automatically created from menu-extras-template.php if missing.
.gitignore changed to ignore any pushes to menu-extras.php once created so your customization
won't be clobbered by a git pull